### PR TITLE
Input focus styling

### DIFF
--- a/frontend/src/components/form/FormInput.jsx
+++ b/frontend/src/components/form/FormInput.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 
-import { Button, Form, InputGroup } from 'react-bootstrap';
+import { useRef, useEffect, useState } from 'react';
+
+import { Form, InputGroup } from 'react-bootstrap';
 
 import { BsExclamationCircle, BsCheckLg } from 'react-icons/bs';
 
@@ -16,49 +18,65 @@ const FormInput = ({
   successMessage,
   showTextPassword,
   labelClassName,
+  type,
   ...props
-}) => (
-  <Form.Group className='py-2'>
-    {/* Container for form input and button */}
+}) => {
+  const inputRef = useRef(null);
+  const [inputValue, setInputValue] = useState('');
 
-    <Form.Label className={labelClassName}>{label}</Form.Label>
-    {/* Label for the form input */}
-    <InputGroup>
-      <Form.Control
-        {...props}
-        className={errorMessage ? styles.errorInput : ''}
-      />
+  useEffect(() => {
+    if (inputRef.current) {
+      setInputValue(inputRef.current.value);
+    }
+  }, []);
 
-      {label === 'Password' && (
-        <Button
-          variant='light'
-          className={errorMessage ? styles.errorInput : styles.formInputButton}
-          onClick={(event) => {
-            event.preventDefault();
-            setShowPassword(!showPassword);
-          }}
-        >
-          {showPassword ? <FaEyeSlash /> : <FaEye />}
-        </Button>
+  const handleInputChange = (e) => {
+    setInputValue(e.target.value);
+  };
+
+  const isPassword = label === 'Password';
+
+  return (
+    <Form.Group className="py-2">
+      <Form.Label className={labelClassName}>{label}</Form.Label>
+      <InputGroup className={styles.inputGroup}>
+        <Form.Control
+          ref={inputRef}
+          {...props}
+          type={isPassword && showPassword ? 'text' : type}
+          className={`${styles.inputField} ${errorMessage ? styles.errorInput : ''}`}
+          value={inputValue}
+          onChange={handleInputChange}
+        />
+        {isPassword && inputValue && (
+          <div
+            className={`${styles.formInputIcon} ${errorMessage ? styles.formInputIconError : ''}`}
+            onClick={() => setShowPassword(!showPassword)}
+            role="button"
+            tabIndex={0}
+          >
+            {showPassword ? <FaEye /> : <FaEyeSlash />}
+          </div>
+        )}
+      </InputGroup>
+      {successMessage && (
+        <Form.Control.Feedback className={`${styles.feedback} ${styles.successFeedback}`} >
+          <BsCheckLg className={`${styles.icon} ${styles.successIcon}`} />
+          {successMessage}
+        </Form.Control.Feedback>
       )}
-    </InputGroup>
-    {successMessage && (
-      <Form.Control.Feedback className={styles.successFeedback}>
-        <BsCheckLg />
-        {successMessage}
-      </Form.Control.Feedback>
-    )}
-    {errorMessage && (
-      <Form.Control.Feedback type='invalid' className={styles.errorFeedback}>
-        <BsExclamationCircle />
-        {errorMessage}
-      </Form.Control.Feedback>
-    )}
-    {showTextPassword && (
-      <Form.Text className={styles.passwordText}>{showTextPassword}</Form.Text>
-    )}
-  </Form.Group>
-);
+      {errorMessage && (
+        <Form.Control.Feedback type="invalid" className={`${styles.feedback} ${styles.errorFeedback}`} >
+          <BsExclamationCircle className={`${styles.icon} ${styles.errorIcon}`} />
+          {errorMessage}
+        </Form.Control.Feedback>
+      )}
+      {showTextPassword && (
+        <Form.Text className={styles.passwordText}>{showTextPassword}</Form.Text>
+      )}
+    </Form.Group>
+  );
+};
 
 FormInput.propTypes = {
   label: PropTypes.string,
@@ -66,7 +84,7 @@ FormInput.propTypes = {
   setShowPassword: PropTypes.func,
   type: PropTypes.string,
   errorMessage: PropTypes.string,
-  labelClassName: PropTypes.string, // PropType for labelClassName
+  labelClassName: PropTypes.string,
   successMessage: PropTypes.string,
   showTextPassword: PropTypes.string,
 };

--- a/frontend/src/components/form/FormInput.jsx
+++ b/frontend/src/components/form/FormInput.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect } from 'react';
 
 import { Form, InputGroup } from 'react-bootstrap';
 
@@ -19,19 +19,24 @@ const FormInput = ({
   showTextPassword,
   labelClassName,
   type,
+  value,
+  onChange,
+  onFocus,
+  onBlur,
   ...props
 }) => {
   const inputRef = useRef(null);
-  const [inputValue, setInputValue] = useState('');
 
   useEffect(() => {
     if (inputRef.current) {
-      setInputValue(inputRef.current.value);
+      inputRef.current.value = value || '';
     }
-  }, []);
+  }, [value]);
 
   const handleInputChange = (e) => {
-    setInputValue(e.target.value);
+    if (onChange) {
+      onChange(e);
+    }
   };
 
   const isPassword = label === 'Password';
@@ -44,11 +49,14 @@ const FormInput = ({
           ref={inputRef}
           {...props}
           type={isPassword && showPassword ? 'text' : type}
-          className={`${styles.inputField} ${errorMessage ? styles.errorInput : ''}`}
-          value={inputValue}
+          className={`${styles.inputField} ${errorMessage ?
+            styles.errorInput : successMessage ? styles.successInput : ''}`}
+          value={value}
           onChange={handleInputChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
         />
-        {isPassword && inputValue && (
+        {isPassword && value && (
           <div
             className={`${styles.formInputIcon} ${errorMessage ? styles.formInputIconError : ''}`}
             onClick={() => setShowPassword(!showPassword)}
@@ -60,13 +68,13 @@ const FormInput = ({
         )}
       </InputGroup>
       {successMessage && (
-        <Form.Control.Feedback className={`${styles.feedback} ${styles.successFeedback}`} >
+        <Form.Control.Feedback className={`${styles.feedback} ${styles.successFeedback}`}>
           <BsCheckLg className={`${styles.icon} ${styles.successIcon}`} />
           {successMessage}
         </Form.Control.Feedback>
       )}
       {errorMessage && (
-        <Form.Control.Feedback type="invalid" className={`${styles.feedback} ${styles.errorFeedback}`} >
+        <Form.Control.Feedback type="invalid" className={`${styles.feedback} ${styles.errorFeedback}`}>
           <BsExclamationCircle className={`${styles.icon} ${styles.errorIcon}`} />
           {errorMessage}
         </Form.Control.Feedback>
@@ -87,6 +95,10 @@ FormInput.propTypes = {
   labelClassName: PropTypes.string,
   successMessage: PropTypes.string,
   showTextPassword: PropTypes.string,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  value: PropTypes.string,
 };
 
 export default FormInput;

--- a/frontend/src/components/form/FormInput.module.css
+++ b/frontend/src/components/form/FormInput.module.css
@@ -4,8 +4,8 @@
 }
 
 .inputField {
-  padding-right: 2.5rem; 
-  border-radius: 8px !important; 
+  padding-right: 2.5rem;
+  border-radius: 8px !important;
   border: 1.5px solid #9eafb7 !important;
   padding: 17.6px 8px !important;
   font-size: 16px !important;
@@ -13,14 +13,32 @@
   color: #596b73 !important;
   background-color: #f6f8f8 !important;
   box-shadow: none !important;
-  border-radius: 8px;
-  transition: box-shadow 0.3s ease, border-color 0.3s ease; 
+  transition: box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 .inputField:focus {
-  border-color: #A4DFE1 !important; 
-  box-shadow: 0px 2px 4px -1px rgba(74, 122, 124, 0.06), 0px 6px 10px -1px rgba(74, 122, 124, 0.1) !important; /* Adjust shadow on focus */
+  border-color: #A4DFE1 !important;
+  box-shadow: 0px 2px 4px -1px rgba(74, 122, 124, 0.06), 0px 6px 10px -1px rgba(74, 122, 124, 0.1) !important;
   outline: none !important;
+}
+
+.successInput {
+  border-color: #5DC968 !important;
+}
+
+.errorInput {
+  border-color: #FF7B72 !important;
+  background-image: none !important;
+}
+
+.inputField.successInput:focus {
+  border-color: #5DC968 !important;
+  box-shadow: 0px 2px 4px -1px rgba(74, 122, 124, 0.06), 0px 6px 10px -1px rgba(74, 122, 124, 0.1) !important;
+}
+
+.inputField.errorInput:focus {
+  border-color: #FF7B72 !important;
+  box-shadow: none !important;
 }
 
 .optionalText {
@@ -31,19 +49,6 @@
   letter-spacing: 0.02em;
   text-align: left;
   color: rgba(89, 107, 115, 1);
-}
-
-/* Error input styles */
-.errorInput {
-  border-color: #da3633 !important;
-  background-image: none !important;
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25) !important;
-}
-
-.errorInput:focus,
-.was-validated .form-control:invalid:focus,
-.form-control.is-invalid:focus {
-  box-shadow: none !important;
 }
 
 /* Icon styles */
@@ -58,7 +63,7 @@
 }
 
 .errorIcon {
-  color: #da3633;
+  color: #DA3633;
 }
 
 /* Feedback styles */
@@ -77,7 +82,8 @@
 }
 
 .errorFeedback {
-  color: #da3633;
+  color: #DA3633;
+  margin-top: 0.5rem;
 }
 
 /* Password visibility icon styles */
@@ -94,11 +100,11 @@
   background: none;
   border: none;
   z-index: 10;
-  color: #000; 
+  color: #000;
 }
 
 .formInputIconError {
-  color: #da3633 !important;
+  color: #DA3633 !important;
 }
 
 /* Password text styles */

--- a/frontend/src/components/form/FormInput.module.css
+++ b/frontend/src/components/form/FormInput.module.css
@@ -1,18 +1,26 @@
 /* General input styles */
+.inputGroup {
+  position: relative;
+}
+
 .inputField {
   padding-right: 2.5rem; 
   border-radius: 8px !important; 
-}
-
-input {
-  border: 1px solid #9eafb7 !important;
+  border: 1.5px solid #9eafb7 !important;
   padding: 17.6px 8px !important;
   font-size: 16px !important;
   line-height: 15.36px !important;
   color: #596b73 !important;
   background-color: #f6f8f8 !important;
-  box-shadow: none;
+  box-shadow: none !important;
   border-radius: 8px;
+  transition: box-shadow 0.3s ease, border-color 0.3s ease; 
+}
+
+.inputField:focus {
+  border-color: #A4DFE1 !important; 
+  box-shadow: 0px 2px 4px -1px rgba(74, 122, 124, 0.06), 0px 6px 10px -1px rgba(74, 122, 124, 0.1) !important; /* Adjust shadow on focus */
+  outline: none !important;
 }
 
 .optionalText {
@@ -29,7 +37,7 @@ input {
 .errorInput {
   border-color: #da3633 !important;
   background-image: none !important;
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25) !important;
 }
 
 .errorInput:focus,
@@ -41,7 +49,7 @@ input {
 /* Icon styles */
 .icon {
   margin: 0 0.3rem 0 0;
-  font-size: 1rem;
+  font-size: 1.5rem;
   vertical-align: middle;
 }
 
@@ -72,14 +80,9 @@ input {
   color: #da3633;
 }
 
-/* Input group styles */
-.inputGroup {
-  position: relative;
-}
-
 /* Password visibility icon styles */
 .formInputIcon {
-  font-size: 1.3rem;
+  font-size: 1.5rem;
   position: absolute;
   right: 2px;
   top: 50%;

--- a/frontend/src/components/form/FormInput.module.css
+++ b/frontend/src/components/form/FormInput.module.css
@@ -1,43 +1,18 @@
-.formInputButton {
+/* General input styles */
+.inputField {
+  padding-right: 2.5rem; 
+  border-radius: 8px !important; 
+}
+
+input {
+  border: 1px solid #9eafb7 !important;
+  padding: 17.6px 8px !important;
+  font-size: 16px !important;
+  line-height: 15.36px !important;
+  color: #596b73 !important;
   background-color: #f6f8f8 !important;
-  border-top: 1px solid #9eafb7;
-  border-bottom: 1px solid #9eafb7;
-  border-right: 1px solid #9eafb7;
-  border-left: 1px solid transparent;
-  
-}
-
-.formInputButton:active,
-.formInputButton:hover,
-.formInputButton:focus,
-.formInputButton:focus-visible,
-.formInputButton:active {
-  border-left: 1px solid transparent !important;
-  background-color: #f6f8f8 !important;
-  
-}
-
-.errorFeedback {
-  display: flex;
-  align-items: center;
-  color: #da3633;
-  font-family: Roboto;
-  font-size: 10px;
-  font-weight: 600;
-  line-height: 14px;
-}
-.errorFeedback svg {
-  margin-right: 5px;
-}
-
-.errorInput {
-  border-color: #da3633;
-  background-image: none !important;
-}
-
-.errorInput:last-child {
-  border-color: #da3633;
-  border-radius: 0px 8px 8px 0px !important;
+  box-shadow: none;
+  border-radius: 8px;
 }
 
 .optionalText {
@@ -50,41 +25,85 @@
   color: rgba(89, 107, 115, 1);
 }
 
-.successFeedback {
-  font-family: Roboto;
-  font-size: 10px;
-  font-weight: 600;
-  line-height: 14px;
-  color: #178222;
-  display: flex;
-  align-items: center;
+/* Error input styles */
+.errorInput {
+  border-color: #da3633 !important;
+  background-image: none !important;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
 }
 
-.errorInput:focus {
-  box-shadow: none;
-}
-
+.errorInput:focus,
 .was-validated .form-control:invalid:focus,
 .form-control.is-invalid:focus {
   box-shadow: none !important;
 }
 
+/* Icon styles */
+.icon {
+  margin: 0 0.3rem 0 0;
+  font-size: 1rem;
+  vertical-align: middle;
+}
+
+.successIcon {
+  color: #178222;
+}
+
+.errorIcon {
+  color: #da3633;
+}
+
+/* Feedback styles */
+.feedback {
+  display: flex;
+  align-items: center;
+  font-family: Roboto;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 14px;
+  margin: 0.7rem 0;
+}
+
+.successFeedback {
+  color: #178222;
+}
+
+.errorFeedback {
+  color: #da3633;
+}
+
+/* Input group styles */
+.inputGroup {
+  position: relative;
+}
+
+/* Password visibility icon styles */
+.formInputIcon {
+  font-size: 1.3rem;
+  position: absolute;
+  right: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  padding: 0 0.75rem;
+  background: none;
+  border: none;
+  z-index: 10;
+  color: #000; 
+}
+
+.formInputIconError {
+  color: #da3633 !important;
+}
+
+/* Password text styles */
 .passwordText {
   font-family: Roboto;
   font-size: 10px;
   font-weight: 600;
   line-height: 14px;
   text-align: left;
+  color: #6c757d;
 }
-
-input {
-  border: 1px solid #9eafb7 !important;
-  padding: 17.6px 8px !important;
-  font-size: 16px !important;
-  line-height: 15.36px !important;
-  color: #596b73 !important;
-  background-color: #f6f8f8 !important;
-  box-shadow: none;
-}
-
-


### PR DESCRIPTION
Test sign in page 

1) When focused, password input border should include the eye

2) If password pattern is correct, the border should be green according to the Figma design:
<img width="500" alt="Screenshot 2024-06-14 at 20 29 50" src="https://github.com/JULIERAJ/KIDS-FIRST-v2/assets/114008959/21fc092f-a308-414b-b00a-88cf70d34093">

3) Focus border color and shadow are added according to the Figma design:
<img width="500" alt="Screenshot 2024-06-14 at 20 28 29" src="https://github.com/JULIERAJ/KIDS-FIRST-v2/assets/114008959/ac85460e-a8b6-48c6-aadb-c7d9774b764d">

4) When password is incorrect, the border and text should be red according to the Figma design:
<img width="500" alt="Screenshot 2024-06-14 at 20 29 25" src="https://github.com/JULIERAJ/KIDS-FIRST-v2/assets/114008959/24ea9aa7-3f8c-4373-a2b6-81a192f4c617">

Note:
1) The are inherited errors in the console
2) Changes in password input should be visible when we remove focus
